### PR TITLE
add circleMarker

### DIFF
--- a/src/Leaflet.SelectAreaFeature.js
+++ b/src/Leaflet.SelectAreaFeature.js
@@ -193,6 +193,11 @@
               layers_found.push(layer);
 		     }
 		   }  
+           if ( (layertype == 'circlemarker' || layertype == 'all') && layer instanceof L.circleMarker  ) {
+	         if ( pol.contains(layer.getLatLng()) ) {
+              layers_found.push(layer);
+		     }
+		   }  
          });
 	     _i++;
 	   }

--- a/src/Leaflet.SelectAreaFeature.js
+++ b/src/Leaflet.SelectAreaFeature.js
@@ -193,7 +193,7 @@
               layers_found.push(layer);
 		     }
 		   }  
-           if ( (layertype == 'circlemarker' || layertype == 'all') && layer instanceof L.circleMarker  ) {
+           if ( (layertype == 'circlemarker' || layertype == 'all') && layer instanceof L.CircleMarker  ) {
 	         if ( pol.contains(layer.getLatLng()) ) {
               layers_found.push(layer);
 		     }


### PR DESCRIPTION
When using getFeaturesSelected, if the map contain circleMarker they are not listed. Add to the list


Side note, why using `==` instead of `===` ?