### PR TITLE
Raise events for onDrawStart and onDrawEnd

### DIFF
--- a/dist/Leaflet.SelectAreaFeature.js
+++ b/dist/Leaflet.SelectAreaFeature.js
@@ -62,7 +62,9 @@
 		this._map.dragging.enable();
     },
 
-	onDrawEnd: null,
+    _onDrawEnd: function(evData) {
+  	  this._map.fire("onDrawEnd", evData);
+    },
 
     _doMouseUp: function(ev) {
   	  this._pre_latlon = null;
@@ -78,14 +80,16 @@
 
 		  this._flag_new_shape = false;
 		  this._map.off('mousemove');
-		  if (this.onDrawEnd) this.onDrawEnd();
+		  this._onDrawEnd(this._ARR_latlon);
 		}
 	},
 
-	onDrawStart: null,
+    _onDrawStart: function(evData) {
+  	  this._map.fire("onDrawStart", evData);
+    },
 
-	_doMouseDown: function(ev) {
-	  if (this.onDrawStart) this.onDrawStart();
+    _doMouseDown: function(ev) {
+	  this._onDrawStart({"latlng" : ev.latlng, "containerPoint" : ev.containerPoint, "layerPoint" : ev.layerPoint});
 
 	  this._ARR_latlon = [];
 	  this._flag_new_shape = true;
@@ -224,4 +228,3 @@
 }, window));
 
 L.Map.addInitHook('addHandler', 'selectAreaFeature', L.SelectAreaFeature);
-

--- a/src/Leaflet.SelectAreaFeature.js
+++ b/src/Leaflet.SelectAreaFeature.js
@@ -62,7 +62,9 @@
 		this._map.dragging.enable();
     },
 
-	onDrawEnd: null,
+    _onDrawEnd: function(evData) {
+  	  this._map.fire("onDrawEnd", evData);
+    },
 
     _doMouseUp: function(ev) {
   	  this._pre_latlon = null;
@@ -78,14 +80,16 @@
 
 		  this._flag_new_shape = false;
 		  this._map.off('mousemove');
-		  if (this.onDrawEnd) this.onDrawEnd();
+		  this._onDrawEnd(this._ARR_latlon);
 		}
 	},
 
-	onDrawStart: null,
+    _onDrawStart: function(evData) {
+  	  this._map.fire("onDrawStart", evData);
+    },
 
-	_doMouseDown: function(ev) {
-	  if (this.onDrawStart) this.onDrawStart();
+    _doMouseDown: function(ev) {
+	  this._onDrawStart({"latlng" : ev.latlng, "containerPoint" : ev.containerPoint, "layerPoint" : ev.layerPoint});
 
 	  this._ARR_latlon = [];
 	  this._flag_new_shape = true;


### PR DESCRIPTION
Hi - this is a small change to raise 2 custom events in leaflet that allow the host application to be notified when selection begins and when selection ends.  Some commonly needed parameters are passed with each event.  This should both provide a standardized way to subscribe to these events and eliminate the need to alter the source code of this library.

Subscribing to the events in the host application is as easy as:

`map.on('onDrawStart', function(evData) {console.log('intercept before drawing begins');};`

`map.on('onDrawEnd', function(selectionLatLng) {console.log('intercept after drawing ends');};`


